### PR TITLE
WIP: Adding support for non-batched dimensions in `vmap`

### DIFF
--- a/src/jax_finufft/ops.py
+++ b/src/jax_finufft/ops.py
@@ -275,6 +275,37 @@ def transpose(type_, doutput, source, *points, output_shape, eps, iflag):
 
 
 def batch(type_, prim, args, axes, **kwargs):
+    source, *points = args
+    bsource, *bpoints = axes
+
+    ndim = len(points)
+    in_axis = -2 if type_ == 1 else -ndim - 1
+    out_axis = -2 if type_ == 2 else -ndim - 1
+
+    if all(bx is batching.not_mapped for bx in bpoints):
+        # If none of the points are being mapped, we can get a faster solve without
+        # broadcasting
+        assert bsource is not batching.not_mapped
+        source = batching.moveaxis(source, bsource, in_axis)
+        source = source.reshape(
+            source.shape[: in_axis - 1] + (-1,) + source.shape[in_axis + 1 :]
+        )
+        result = prim.bind(source, *points, **kwargs)
+        return (
+            result.reshape(
+                result.shape[: out_axis - 1]
+                + (-1, source.shape[in_axis])
+                + result.shape[out_axis + 1 :]
+            ),
+            out_axis,
+        ), out_axis
+
+    else:
+        # Otherwise move the batching dimension to the front and broadcast all the
+        # arrays
+        pass
+        # points = jnp.broadcast_arrays(*())
+
     ndim = len(args) - 1
     if type_ == 1:
         mx = args[0].ndim - 2


### PR DESCRIPTION
In most cases, we'll just need to broadcast all the inputs out to the right shapes (this shouldn't be too hard), but when none of the points get mapped, we can get a bit of a speed up by stacking the transforms. This starts to implement that logic, but it's not quite ready yet.