### PR TITLE
update ShapedArray import

### DIFF
--- a/src/jax_finufft/shapes.py
+++ b/src/jax_finufft/shapes.py
@@ -6,7 +6,7 @@ from typing import Sequence
 import jax.numpy as jnp
 import numpy as np
 from jax import dtypes
-from jax.abstract_arrays import ShapedArray
+from jax.core import ShapedArray
 
 
 @dataclass

--- a/src/jax_finufft/translation.py
+++ b/src/jax_finufft/translation.py
@@ -6,7 +6,7 @@ from jax.lib import xla_client
 from . import jax_finufft
 
 for _name, _value in jax_finufft.registrations().items():
-    xla_client.register_cpu_custom_call_target(_name, _value)
+    xla_client.register_custom_call_target(_name, _value, platform="cpu")
 
 xops = xla_client.ops
 


### PR DESCRIPTION
Starting with jax 0.4.16 jax.abstract_arrays.ShapedArray is deprecated

See: https://github.com/google/jax/blob/main/CHANGELOG.md
