### PR TITLE
Using jax test_utils for dtype-aware test tolerances

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = ["jax", "jaxlib"]
 dynamic = ["version"]
 
 [project.optional-dependencies]
-test = ["pytest"]
+test = ["pytest", "absl-py"]
 
 [tool.scikit-build]
 metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"


### PR DESCRIPTION
This should provide somewhat more robust floating point comparisons that handle dtypes appropriately.